### PR TITLE
adding make install instructions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,3 +7,6 @@ if(SHARED)
 else(SHARED)
   add_library(apfel STATIC $<TARGET_OBJECTS:kernel> $<TARGET_OBJECTS:evolution_module>)
 endif(SHARED)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/inc/apfel DESTINATION include)
+install(TARGETS apfel DESTINATION lib)


### PR DESCRIPTION
@vbertone this commit implements the `make install` instruction. 
Could you please test and let me know if it works fine in your system?
You can control the installation path with `CMAKE_INSTALL_PREFIX`.